### PR TITLE
Remove signs that are achievable by composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+### Removed
+
+- `Sign::inequality`
+- `Sign::lessThanOrEqual`
+- `Sign::moreThanOrEqual`
+- `Sign::isNull`
+- `Sign::isNotNull`

--- a/src/Sign.php
+++ b/src/Sign.php
@@ -9,13 +9,8 @@ namespace Innmind\Specification;
 enum Sign
 {
     case equality;
-    case inequality;
     case lessThan;
     case moreThan;
-    case lessThanOrEqual;
-    case moreThanOrEqual;
-    case isNull;
-    case isNotNull;
     case startsWith;
     case endsWith;
     case contains;


### PR DESCRIPTION
## Problem

There are signs that are also achievable by composition. This means there are multiple ways to write the same query.

This complexifies implementations that translate specifications to language specific queries.

## Solution

This PR removes all `Sign`s that are achievable by composition.

## Note

`Sign::in` is kept as it allows defining [SQL sub queries](https://formal-php.github.io/access-layer/queries/select/#filter-rows)